### PR TITLE
Download check if exists

### DIFF
--- a/ltr/client/elastic_client.py
+++ b/ltr/client/elastic_client.py
@@ -54,6 +54,9 @@ class ElasticClient(BaseClient):
 
     def name(self):
         return "elastic"
+    
+    def check_index_exists(self, index):
+        return self.es.indices.exists(index=index)
 
     def delete_index(self, index):
         resp = self.es.indices.delete(index=index, ignore=[400, 404])

--- a/ltr/client/solr_client.py
+++ b/ltr/client/solr_client.py
@@ -1,4 +1,5 @@
 import os
+import re
 import requests
 
 from .base_client import BaseClient
@@ -16,6 +17,10 @@ class SolrClient(BaseClient):
 
     def name(self):
         return "solr"
+    
+    def check_index_exists(self, index):
+        resp = requests.get('{}/admin/cores?action=STATUS&core={}'.format(self.solr_base_ep, index))
+        return bool(re.search('instanceDir', str(resp.content)))
 
     def delete_index(self, index):
         params = {

--- a/ltr/download.py
+++ b/ltr/download.py
@@ -1,4 +1,6 @@
 import requests
+import os.path
+from os import path
 
 def download():
     resources = [
@@ -13,7 +15,11 @@ def download():
 
     def download(uri):
         filename = uri[uri.rfind('/') + 1:]
-        with open('data/{}'.format(filename), 'wb') as out:
+        filepath = 'data/{}'.format(filename)
+        if path.exists(filepath):
+            print(filepath + ' already exists')
+            return 
+        with open(filepath, 'wb') as out:
             print('GET {}'.format(uri))
             resp = requests.get(uri, stream=True)
             for chunk in resp.iter_content(chunk_size=1024):

--- a/ltr/index.py
+++ b/ltr/index.py
@@ -1,25 +1,32 @@
 from ltr.helpers.movies import indexable_movies, noop
 
-def rebuild(client, index, doc_type, doc_src):
+def rebuild(client, index, doc_type, doc_src, force=False):
     """ Reload a configuration on disk for each search engine
         (Solr a configset, Elasticsearch a json file)
         and reindex
 
         """
-    print("Reconfig from disk...")
-
-    client.delete_index(index)
-    client.create_index(index)
-
-    print("Reindexing...")
-
-    client.index_documents(index,
-                           doc_type=doc_type,
-                           doc_src=doc_src)
-
+    
+    if (client.check_index_exists):
+        if (force):
+            client.delete_index(index)
+            client.create_index(index)
+            client.index_documents(index,
+                                   doc_type=doc_type,
+                                   doc_src=doc_src)
+        else:
+            print("Index {} already exists. Use `force = True` to delete and recreate".format(index))
+            return None
+    else:
+        client.delete_index(index)
+        client.create_index(index)
+        client.index_documents(index,
+                               doc_type=doc_type,
+                               doc_src=doc_src)
+            
     print('Done')
 
 
-def rebuild_tmdb(client, enrich=noop):
+def rebuild_tmdb(client, enrich=noop, force=False):
     movies=indexable_movies(enrich=enrich)
-    rebuild(client, index='tmdb', doc_type='movie', doc_src=movies)
+    rebuild(client, index='tmdb', doc_type='movie', doc_src=movies, force = force)


### PR DESCRIPTION
Might be overkill, but I got tired of the re-downloading and re-indexing operations when I was running all of the notebooks, so I made these changes:

1. If files exists locally, don't download them again in ltr/download.py
2. Add argument `force = False` to rebuild_index(), so if the index already exists (which it usually does and I didn't see code altering the index), don't re-index just tell the user about `force = True`