### PR TITLE
Upgrade solr/elastic to latest versions. Remove deprecated type

### DIFF
--- a/ltr/client/elastic_client.py
+++ b/ltr/client/elastic_client.py
@@ -69,14 +69,13 @@ class ElasticClient(BaseClient):
             resp = self.es.indices.create(index, body=settings)
             resp_msg(msg="Created index {}".format(index), resp=ElasticResp(resp))
 
-    def index_documents(self, index, doc_type, doc_src):
+    def index_documents(self, index, doc_src):
 
         def bulkDocs(doc_src):
             for doc in doc_src:
                 if 'id' not in doc:
                     raise ValueError("Expecting docs to have field 'id' that uniquely identifies document")
                 addCmd = {"_index": index,
-                          "_type": doc_type,
                           "_id": doc['id'],
                           "_source": doc}
                 yield addCmd
@@ -230,8 +229,8 @@ class ElasticClient(BaseClient):
 
         return mapping, rawFeatureSet
 
-    def get_doc(self, doc_id, index, doc_type='movie'):
-        resp = self.es.get(index=index, doc_type=doc_type, id=doc_id)
+    def get_doc(self, doc_id, index):
+        resp = self.es.get(index=index, id=doc_id)
         #resp_msg(msg="Fetched Doc".format(docId), resp=ElasticResp(resp), throw=False)
         return resp['_source']
 

--- a/ltr/client/solr_client.py
+++ b/ltr/client/solr_client.py
@@ -42,7 +42,7 @@ class SolrClient(BaseClient):
         resp = requests.get('{}/admin/cores?'.format(self.solr_base_ep), params=params)
         resp_msg(msg="Created index {}".format(index), resp=resp)
 
-    def index_documents(self, index, doc_type, doc_src):
+    def index_documents(self, index, doc_src):
         def commit():
             resp = requests.get('{}/{}/update?commit=true'.format(self.solr_base_ep, index))
             resp_msg(msg="Committed index {}".format(index), resp=resp)

--- a/ltr/index.py
+++ b/ltr/index.py
@@ -1,6 +1,6 @@
 from ltr.helpers.movies import indexable_movies, noop
 
-def rebuild(client, index, doc_type, doc_src):
+def rebuild(client, index, doc_src):
     """ Reload a configuration on disk for each search engine
         (Solr a configset, Elasticsearch a json file)
         and reindex
@@ -14,7 +14,6 @@ def rebuild(client, index, doc_type, doc_src):
     print("Reindexing...")
 
     client.index_documents(index,
-                           doc_type=doc_type,
                            doc_src=doc_src)
 
     print('Done')
@@ -22,4 +21,4 @@ def rebuild(client, index, doc_type, doc_src):
 
 def rebuild_tmdb(client, enrich=noop):
     movies=indexable_movies(enrich=enrich)
-    rebuild(client, index='tmdb', doc_type='movie', doc_src=movies)
+    rebuild(client, index='tmdb', doc_src=movies)

--- a/notebooks/elasticsearch/.docker/es-docker/Dockerfile
+++ b/notebooks/elasticsearch/.docker/es-docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.2
 
-RUN bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.1.0-es6.4.1.zip
+RUN bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.2.1-es7.6.2.zip 
 COPY --chown=elasticsearch:elasticsearch elasticsearch.yml /usr/share/elasticsearch/config/
 RUN cat  /usr/share/elasticsearch/config/elasticsearch.yml
 

--- a/notebooks/elasticsearch/.docker/es-docker/elasticsearch.yml
+++ b/notebooks/elasticsearch/.docker/es-docker/elasticsearch.yml
@@ -92,3 +92,5 @@ http.cors.allow-origin: "/http?:.*/"
 http.cors.enabled: true
 indices.query.bool.max_clause_count: 10240
 network.host: 0.0.0.0
+
+discovery.type: single-node

--- a/notebooks/elasticsearch/.docker/kb-docker/Dockerfile
+++ b/notebooks/elasticsearch/.docker/kb-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/kibana/kibana:6.4.1
+FROM docker.elastic.co/kibana/kibana:7.6.2
 
-RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/6.4.1/analyze-api-ui-plugin-6.4.1.zip 
+RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.6.2/analyze_api_ui-7.6.2.zip 
 

--- a/notebooks/elasticsearch/osc-blog/blog_settings.json
+++ b/notebooks/elasticsearch/osc-blog/blog_settings.json
@@ -1,63 +1,61 @@
 {
   "mappings": {
-    "post": {
-      "_source": {
-        "enabled": true
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "post_id": {
+        "type": "long",
+        "store": true
       },
-      "properties": {
-        "post_id": {
-          "type": "long",
-          "store": true
-        },
-        "post_date": {
-          "type": "date",
-          "store": true
-        },
-        "es_update_date": {
-          "type": "date",
-          "store": true
-        },
-        "url": {
-          "type": "text",
-          "store": true
-        },
-        "title": {
-          "type": "text",
-          "store": true,
-          "analyzer": "content_analyzer",
-          "fields": {
-            "bigrams": {
-              "type": "text",
-              "analyzer": "content_bigrams"
-            }
+      "post_date": {
+        "type": "date",
+        "store": true
+      },
+      "es_update_date": {
+        "type": "date",
+        "store": true
+      },
+      "url": {
+        "type": "text",
+        "store": true
+      },
+      "title": {
+        "type": "text",
+        "store": true,
+        "analyzer": "content_analyzer",
+        "fields": {
+          "bigrams": {
+            "type": "text",
+            "analyzer": "content_bigrams"
           }
-        },
-        "author": {
-          "type": "text",
-          "store": true,
-          "analyzer": "standard"
-        },
-        "content": {
-          "type": "text",
-          "store": true,
-          "analyzer": "content_analyzer",
-          "fields": {
-            "bigrams": {
-              "type": "text",
-              "analyzer": "content_bigrams"
-            }
-          }
-        },
-        "excerpt": {
-          "type": "text",
-          "store": true,
-          "analyzer": "content_analyzer"
-        },
-        "categories": {
-          "type": "text",
-          "store": true,
-          "analyzer": "content_analyzer"
         }
+      },
+      "author": {
+        "type": "text",
+        "store": true,
+        "analyzer": "standard"
+      },
+      "content": {
+        "type": "text",
+        "store": true,
+        "analyzer": "content_analyzer",
+        "fields": {
+          "bigrams": {
+            "type": "text",
+            "analyzer": "content_bigrams"
+          }
+        }
+      },
+      "excerpt": {
+        "type": "text",
+        "store": true,
+        "analyzer": "content_analyzer"
+      },
+      "categories": {
+        "type": "text",
+        "store": true,
+        "analyzer": "content_analyzer"
       }
     }
   },

--- a/notebooks/elasticsearch/osc-blog/osc-blog.ipynb
+++ b/notebooks/elasticsearch/osc-blog/osc-blog.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "from ltr.index import rebuild\n",
-    "rebuild(client, index='blog', doc_type='post', doc_src=articles)"
+    "rebuild(client, index='blog', doc_src=articles)"
    ]
   },
   {

--- a/notebooks/elasticsearch/tmdb/tmdb_settings.json
+++ b/notebooks/elasticsearch/tmdb/tmdb_settings.json
@@ -1,195 +1,193 @@
 {
   "mappings": {
-    "movie": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "analyzer": "my_english",
-          "fields": {
-            "wdf": {
-              "type": "text",
-              "analyzer": "my_wdf"
-            },
-            "keyword": {
-              "type": "text",
-              "analyzer": "my_keyword"
-            }
+    "properties": {
+      "title": {
+        "type": "text",
+        "analyzer": "my_english",
+        "fields": {
+          "wdf": {
+            "type": "text",
+            "analyzer": "my_wdf"
           },
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms"
-          ]
+          "keyword": {
+            "type": "text",
+            "analyzer": "my_keyword"
+          }
         },
-        "release_date": {
-          "type": "date",
-          "format": "yyyy-MM-dd"
-        },
-        "release_year": {
-            "type": "short"
-        },
-        "tagline": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ]
-        },
-        "directors": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_people",
-            "text_people2",
-            "text_people_notf",
-            "text_std_gr_idx_syn",
-            "text_people_syn",
-            "text_std_syn",
-            "text_people_gr_idx_syn",
-            "text_std_idioms",
-            "text_people_notf_front",
-            "text_people_bigram"
-          ]
-        },
-        "cast": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_people",
-            "text_people2",
-            "text_people_notf",
-            "text_std_gr_idx_syn",
-            "text_people_syn",
-            "text_std_syn",
-            "text_people_gr_idx_syn",
-            "text_std_idioms",
-            "text_people_notf_front",
-            "text_people_bigram"
-          ]
-        },
-        "overview": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ]
-        },
-        "genres": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ],
-          "fielddata": true
-        },
-        "text_all": {
-          "type": "text",
-          "analyzer": "my_english"
-        },
-        "text_people": {
-          "type": "text",
-          "analyzer": "my_english",
-          "fielddata": true,
-          "store": true
-        },
-        "text_people_bigram": {
-          "type": "text",
-          "analyzer": "names_bigram",
-          "fielddata": true,
-          "store": true,
-          "similarity": "no_tf_similarity"
-        },
-        "text_std": {
-          "type": "text",
-          "analyzer": "standard",
-          "search_analyzer": "std_syn",
-          "store": true
-        },
-        "text_std_idioms": {
-          "type": "text",
-          "analyzer": "std_idioms",
-          "store": true
-        },
-        "text_std_tax": {
-          "type": "text",
-          "analyzer": "std_tax",
-          "store": true
-        },
-        "text_std_tax_phrase": {
-          "type": "text",
-          "analyzer": "std_tax_phrase_idx",
-          "search_analyzer": "std_tax_phrase_q",
-          "store": true
-        },
-        "text_std_gr_idx_syn": {
-          "type": "text",
-          "analyzer": "std_syn_gr_multiterm",
-          "store": true
-        },
-        "text_people_gr_idx_syn": {
-          "type": "text",
-          "analyzer": "std_syn_gr_multiterm",
-          "store": true
-        },
-        "text_std_syn_mt": {
-          "type": "text",
-          "analyzer": "std_syn_multiterm",
-          "store": true
-        },
-        "text_people_syn_mt": {
-          "type": "text",
-          "analyzer": "std_syn_multiterm",
-          "store": true
-        },
-        "text_std_syn": {
-          "type": "text",
-          "analyzer": "std_syn_bidirect",
-          "store": true
-        },
-        "text_people_syn": {
-          "type": "text",
-          "analyzer": "std_syn_bidirect",
-          "store": true
-        },
-        "text_people2": {
-          "type": "text",
-          "analyzer": "names",
-          "store": true
-        },
-        "text_people_notf": {
-          "type": "text",
-          "analyzer": "names",
-          "similarity": "no_tf_similarity"
-        },
-        "text_people_notf_front": {
-          "type": "text",
-          "analyzer": "names_front",
-          "similarity": "no_tf_similarity"
-        }
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms"
+        ]
+      },
+      "release_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd"
+      },
+      "release_year": {
+          "type": "short"
+      },
+      "tagline": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ]
+      },
+      "directors": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_people",
+          "text_people2",
+          "text_people_notf",
+          "text_std_gr_idx_syn",
+          "text_people_syn",
+          "text_std_syn",
+          "text_people_gr_idx_syn",
+          "text_std_idioms",
+          "text_people_notf_front",
+          "text_people_bigram"
+        ]
+      },
+      "cast": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_people",
+          "text_people2",
+          "text_people_notf",
+          "text_std_gr_idx_syn",
+          "text_people_syn",
+          "text_std_syn",
+          "text_people_gr_idx_syn",
+          "text_std_idioms",
+          "text_people_notf_front",
+          "text_people_bigram"
+        ]
+      },
+      "overview": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ]
+      },
+      "genres": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ],
+        "fielddata": true
+      },
+      "text_all": {
+        "type": "text",
+        "analyzer": "my_english"
+      },
+      "text_people": {
+        "type": "text",
+        "analyzer": "my_english",
+        "fielddata": true,
+        "store": true
+      },
+      "text_people_bigram": {
+        "type": "text",
+        "analyzer": "names_bigram",
+        "fielddata": true,
+        "store": true,
+        "similarity": "no_tf_similarity"
+      },
+      "text_std": {
+        "type": "text",
+        "analyzer": "standard",
+        "search_analyzer": "std_syn",
+        "store": true
+      },
+      "text_std_idioms": {
+        "type": "text",
+        "analyzer": "std_idioms",
+        "store": true
+      },
+      "text_std_tax": {
+        "type": "text",
+        "analyzer": "std_tax",
+        "store": true
+      },
+      "text_std_tax_phrase": {
+        "type": "text",
+        "analyzer": "std_tax_phrase_idx",
+        "search_analyzer": "std_tax_phrase_q",
+        "store": true
+      },
+      "text_std_gr_idx_syn": {
+        "type": "text",
+        "analyzer": "std_syn_gr_multiterm",
+        "store": true
+      },
+      "text_people_gr_idx_syn": {
+        "type": "text",
+        "analyzer": "std_syn_gr_multiterm",
+        "store": true
+      },
+      "text_std_syn_mt": {
+        "type": "text",
+        "analyzer": "std_syn_multiterm",
+        "store": true
+      },
+      "text_people_syn_mt": {
+        "type": "text",
+        "analyzer": "std_syn_multiterm",
+        "store": true
+      },
+      "text_std_syn": {
+        "type": "text",
+        "analyzer": "std_syn_bidirect",
+        "store": true
+      },
+      "text_people_syn": {
+        "type": "text",
+        "analyzer": "std_syn_bidirect",
+        "store": true
+      },
+      "text_people2": {
+        "type": "text",
+        "analyzer": "names",
+        "store": true
+      },
+      "text_people_notf": {
+        "type": "text",
+        "analyzer": "names",
+        "similarity": "no_tf_similarity"
+      },
+      "text_people_notf_front": {
+        "type": "text",
+        "analyzer": "names_front",
+        "similarity": "no_tf_similarity"
       }
     }
   },

--- a/notebooks/solr/.docker/solr_home/tmdb/conf/solrconfig.xml
+++ b/notebooks/solr/.docker/solr_home/tmdb/conf/solrconfig.xml
@@ -1427,11 +1427,7 @@
     -->
 
   <queryResponseWriter name="json" class="solr.JSONResponseWriter">
-    <!-- For the purposes of the tutorial, JSON responses are written as
-     plain text so that they are easy to read in *any* browser.
-     If you expect a MIME type of "application/json" just remove this override.
-    -->
-    <str name="content-type">text/plain; charset=UTF-8</str>
+    <str name="content-type">text/javascript; charset=UTF-8</str>
   </queryResponseWriter>
 
   <!--

--- a/notebooks/solr/Dockerfile
+++ b/notebooks/solr/Dockerfile
@@ -1,12 +1,12 @@
-FROM solr:7.7.1
+FROM solr:8.5.1
 
 USER root
 
-ADD tmdb/solr_config server/solr/configsets/tmdb
-RUN chown solr:solr server/solr/configsets/tmdb
+ADD tmdb/solr_config /var/solr/data/configsets/tmdb
+RUN chown solr:solr /var/solr/data/configsets/tmdb
 
-ADD msmarco/solr_config server/solr/configsets/msmarco
-RUN chown solr:solr server/solr/configsets/msmarco
+ADD msmarco/solr_config /var/solr/data/configsets/msmarco
+RUN chown solr:solr /var/solr/data/configsets/msmarco
 
 USER solr
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==3.0.4
 cycler==0.10.0
 decorator==4.3.2
 defusedxml==0.5.0
-elasticsearch==6.3.1
+elasticsearch==7.0.0
 entrypoints==0.3
 fuzzywuzzy==0.18.0
 idna==2.8


### PR DESCRIPTION
Update to shiny new versions of elastic and solr.

Solr required a path change in the Dockerfile, otherwise no issues.
Elastic required a configuration change and removal of `type` from the client code and schema.

Passes the run_most_notebooks tests.

**Note**:   If you have an existing environment, this requires a docker image rebuild and refreshing your python dependencies with a `pip install -r requirements.txt`