### PR TITLE
Make hello-ltr (ES) classic and latest model results easier to understand

### DIFF
--- a/ltr/client/elastic_client.py
+++ b/ltr/client/elastic_client.py
@@ -200,7 +200,9 @@ class ElasticClient(BaseClient):
         # Transform to consistent format between ES/Solr
         matches = []
         for hit in resp['hits']['hits']:
-            matches.append(hit['_source'])
+            match = hit['_source']
+            match['_score'] = hit['_score']
+            matches.append(match)
 
         return matches
 

--- a/ltr/release_date_plot.py
+++ b/ltr/release_date_plot.py
@@ -8,7 +8,7 @@ def search(client, user_query, model_name):
                 "must": {"match_all": {} },
                 "filter": {
                     "match": {"title": user_query}
-                    }
+                }
             }
         }
     else:
@@ -33,7 +33,7 @@ def plot(client, query):
         y = [x['release_year'] for x in modelData[0]],
         mode = "lines",
         name = "classic",
-        text = [x['title'] for x in modelData[0]] # show movie title on hover
+        text = [f'{x["title"]} ({x["_score"]})' for x in modelData[0]]
     )
 
     trace1 = go.Scatter(
@@ -41,7 +41,7 @@ def plot(client, query):
         y = [x['release_year'] for x in modelData[1]],
         mode = "lines",
         name = "latest",
-        text = [x['title'] for x in modelData[1]] # show movie title on hover
+        text = [f'{x["title"]} ({x["_score"]})' for x in modelData[1]]
     )
 
 

--- a/ltr/release_date_plot.py
+++ b/ltr/release_date_plot.py
@@ -32,14 +32,16 @@ def plot(client, query):
         x = xAxes,
         y = [x['release_year'] for x in modelData[0]],
         mode = "lines",
-        name = "classic"
+        name = "classic",
+        text = [x['title'] for x in modelData[0]] # show movie title on hover
     )
 
     trace1 = go.Scatter(
         x = xAxes,
         y = [x['release_year'] for x in modelData[1]],
         mode = "lines",
-        name = "latest"
+        name = "latest",
+        text = [x['title'] for x in modelData[1]] # show movie title on hover
     )
 
 

--- a/ltr/release_date_plot.py
+++ b/ltr/release_date_plot.py
@@ -1,26 +1,28 @@
 import plotly.graph_objs as go
 from plotly.offline import download_plotlyjs, init_notebook_mode, plot, iplot
 
-def plot(client):
+def search(client, user_query, model_name):
+    if client.name() == 'elastic':
+        engine_query = {
+            "bool": {
+                "must": {"match_all": {} },
+                "filter": {
+                    "match": {"title": user_query}
+                    }
+            }
+        }
+    else:
+        engine_query = 'title:('+ user_query + ')^0'    
+    return client.model_query('tmdb', model_name, {}, engine_query)
+
+def plot(client, query):
     init_notebook_mode(connected=True)
 
     models = ['classic', 'latest']
     modelData = []
 
-    if client.name() == 'elastic':
-        query = {
-            "bool": {
-                "must": {"match_all": {} },
-                "filter": {
-                    "match": {"title": "batman"}
-                    }
-            }
-        }
-    else:
-        query = 'title:(batman)^0'
-
     for model in models:
-        modelData.append(client.model_query('tmdb', model, {}, query))
+        modelData.append(search(client, query, model))
 
     xAxes = []
     for i in range(len(modelData[0])):

--- a/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
+++ b/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
@@ -128,7 +128,7 @@
    "source": [
     "## Is this thing on?\n",
     "\n",
-    "Before we dive into all the pieces, with a real training set, we'll try out two examples of models. One that always prefers newer movies. And another that always prefers older movies. If you're curious you can open `classic-training.txt` and `latest-training.txt` after running this to see what the training set looks like. "
+    "Before we dive into all the pieces, with a real training set, we'll try out two examples of models. One that always prefers newer movies. And another that always prefers older movies. If you're curious you can opet `classic-training.txt` and `latest-training.txt` after running this to see what the training set looks like. "
    ]
   },
   {
@@ -190,8 +190,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ltr.release_date_plot import plot\n",
-    "plot(client)"
+    "import ltr.release_date_plot as rdp\n",
+    "rdp.plot(client, 'batman')"
    ]
   },
   {
@@ -199,7 +199,23 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import pandas as pd\n",
+    "classic_results = rdp.search(client, 'batman', 'classic')\n",
+    "print('top results from classic model:')\n",
+    "pd.json_normalize(classic_results)[['id', 'title', 'release_year']].head(12)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latest_results = rdp.search(client, 'batman', 'latest')\n",
+    "print('top results from latest model:')\n",
+    "pd.json_normalize(latest_results)[['id', 'title', 'release_year']].head(12)"
+   ]
   }
  ],
  "metadata": {
@@ -218,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
+++ b/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
@@ -199,11 +199,18 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "classic_results = rdp.search(client, 'batman', 'classic')\n",
     "print('top results from classic model:')\n",
-    "pd.json_normalize(classic_results)[['id', 'title', 'release_year']].head(12)"
+    "pd.json_normalize(classic_results)[['id', 'title', 'release_year', '_score']].head(12)"
    ]
   },
   {
@@ -214,7 +221,7 @@
    "source": [
     "latest_results = rdp.search(client, 'batman', 'latest')\n",
     "print('top results from latest model:')\n",
-    "pd.json_normalize(latest_results)[['id', 'title', 'release_year']].head(12)"
+    "pd.json_normalize(latest_results)[['id', 'title', 'release_year', '_score']].head(12)"
    ]
   }
  ],

--- a/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
+++ b/notebooks/elasticsearch/tmdb/hello-ltr (ES).ipynb
@@ -128,7 +128,7 @@
    "source": [
     "## Is this thing on?\n",
     "\n",
-    "Before we dive into all the pieces, with a real training set, we'll try out two examples of models. One that always prefers newer movies. And another that always prefers older movies. If you're curious you can opet `classic-training.txt` and `latest-training.txt` after running this to see what the training set looks like. "
+    "Before we dive into all the pieces, with a real training set, we'll try out two examples of models. One that always prefers newer movies. And another that always prefers older movies. If you're curious you can open `classic-training.txt` and `latest-training.txt` after running this to see what the training set looks like. "
    ]
   },
   {


### PR DESCRIPTION
git log --oneline
450bb75 (HEAD -> master, origin/master, origin/HEAD) Showing relevance scores in the plot and in the ES hello LTR notebook.
74cece0 Added movie title on release date plot so that the results can be easily interpreted.
f89e276 hello-ltr (ES).ipynb now shows top-12 search results for both classic and latest models.
8e616f7 Fixed minor typo: opet -> open