### PR TITLE
ES/Kibana upgrade + accompanying changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       context: ./notebooks/elasticsearch/.docker/es-docker/
       dockerfile: Dockerfile
     container_name: hello-ltr-elastic
+    environment:
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
     ports:
       - 9200:9200
 

--- a/notebooks/elasticsearch/.docker/es-docker/Dockerfile
+++ b/notebooks/elasticsearch/.docker/es-docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.8.2
 
 RUN bin/elasticsearch-plugin install --batch \
-  "https://github.com/o19s/elasticsearch-learning-to-rank/releases/download/v1.5.8-es7.16.2/ltr-plugin-v1.5.8-es7.16.2.zip"
+  "https://github.com/o19s/elasticsearch-learning-to-rank/releases/download/v1.5.8-es8.8.2/ltr-plugin-v1.5.8-es8.8.2.zip"
 
 COPY --chown=elasticsearch:elasticsearch elasticsearch.yml /usr/share/elasticsearch/config/
 RUN cat  /usr/share/elasticsearch/config/elasticsearch.yml

--- a/notebooks/elasticsearch/.docker/es-docker/elasticsearch.yml
+++ b/notebooks/elasticsearch/.docker/es-docker/elasticsearch.yml
@@ -92,5 +92,8 @@ http.cors.allow-origin: "/http?:.*/"
 http.cors.enabled: true
 indices.query.bool.max_clause_count: 10240
 network.host: 0.0.0.0
+xpack.security.enabled: false
+xpack.security.enrollment.enabled: false
+indices.id_field_data.enabled: true
 
 discovery.type: single-node

--- a/notebooks/elasticsearch/.docker/kb-docker/Dockerfile
+++ b/notebooks/elasticsearch/.docker/kb-docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.elastic.co/kibana/kibana:7.16.2
+FROM docker.elastic.co/kibana/kibana:8.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,9 @@ Jinja2==3.0.3
 joblib==1.1.1
 jsonschema==4.4.0
 jupyter
-jupyter-client==7.1.2
+jupyter-client==7.4.4
 jupyter-console==6.4.0
-jupyter-core==4.9.1
+jupyter-core==4.12
 kiwisolver==1.3.2
 Mako==1.1.6
 MarkupSafe==2.0.1
@@ -34,11 +34,11 @@ matplotlib==3.7.2
 mistune
 mizani==0.9.2
 nbconvert==6.5.0
-nbformat==5.1.3
+nbformat==5.3.0
 nbgrader
 nbstripout==0.5.0
 notebook==6.4.8
-numpy==1.25.2
+numpy==1.23.5
 opensearch-py==2.2.0
 pandas==2.0.3
 pandocfilters==1.5.0
@@ -61,7 +61,7 @@ qtconsole==5.2.2
 requests==2.27.1
 retrying==1.3.3
 scikit-learn==1.3.0
-scipy==1.11.2
+scipy==1.10.1
 seaborn==0.11.2
 Send2Trash==1.8.0
 six==1.16.0
@@ -70,7 +70,7 @@ SQLAlchemy==1.3.24
 terminado==0.13.1
 testpath==0.5.0
 threadpoolctl==3.1.0
-tornado==6.1
+tornado==6.2
 tqdm==4.62.3
 traitlets
 urllib3==1.26.8


### PR DESCRIPTION
- Updated ES + Kibana to 8.8.2
- Included the ES-LTR version matching ES 8.8.2
- ES config changes resulting from the upgrade:
    - Disabled security (auth + tls) as this is not necessary in the context of this repository.
    - `indices.id_field_data.enabled`: true (see below for explanation)
- Version changes in Python libs to make Jupyter Docker container build successful

Reference for the ES config change:
"Previously, it was possible to aggregate and sort on the built-in _id field by loading an expensive data structure called fielddata. This was deprecated in 7.6 and is now disallowed by default in 8.0." (https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html)