### PR TITLE
Fix docker build, due to dependency conflict with jupyter-server and traitlets 5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ testpath==0.5.0
 threadpoolctl==3.1.0
 tornado==6.2
 tqdm==4.62.3
-traitlets
+traitlets==5.9.0
 urllib3==1.26.8
 wcwidth==0.2.5
 webencodings==0.5.1


### PR DESCRIPTION
Docker build for the notebook container fails, due traitlets 5.10 version. 
Downgrade to 5.9 fixes this see: 
https://github.com/jupyter/notebook/issues/7048